### PR TITLE
Fix: Update Deprecated Plotly Color Bar Config

### DIFF
--- a/cect/ConnectomeDataset.py
+++ b/cect/ConnectomeDataset.py
@@ -823,11 +823,12 @@ class ConnectomeDataset:
                 reversescale=True,
                 color=[],
                 size=DEFAULT_NODE_SIZE,
-                colorbar=dict(
-                    thickness=15,
-                    title="Node Connections",
-                    xanchor="left",
-                ),
+                colorbar={
+                    "thickness": 15,
+                    "title": "Node Connections",
+                    "xanchor": "left",
+                    "title.side": "right"
+                },
                 line_width=1,
             ),
             opacity=1,


### PR DESCRIPTION
Update the deprecated plotly.py color bar configuration to have the proper title side definition.

When trying to test the [test_varshney.py](https://github.com/openworm/ConnectomeToolbox/blob/feature/pytest/cect/tests/test_varshney.py) file to work towards issue #38 , an error arises:

>ValueError: Invalid property specified for object of type plotly.graph_objs.scatter.marker.ColorBar: 'titleside'

The error originates from the now deprecated means of setting the plotly title side. This is now amended with the [current way of setting the title's side](https://github.com/plotly/plotly.py/blob/2799251c602b48857a8d3fcd29e6347b76d85d97/doc/python/v6-changes.md?plain=1#L77). 