### PR TITLE
Feature: Create `get_instance` for White Data Reader

### DIFF
--- a/cect/WhiteDataReader.py
+++ b/cect/WhiteDataReader.py
@@ -7,23 +7,20 @@
 ############################################################
 
 
-from cect.ConnectomeReader import ConnectionInfo
-from cect.ConnectomeReader import analyse_connections
-from cect.Cells import convert_to_preferred_muscle_name
-from cect.Cells import is_herm_neuron
-from cect.Cells import is_potential_muscle
-from cect.Cells import is_known_muscle
-from cect.Cells import remove_leading_index_zero
-
-from cect.ConnectomeDataset import LOAD_READERS_FROM_CACHE_BY_DEFAULT
-from cect.ConnectomeDataset import ConnectomeDataset
-
 import os
 
 from cect import print_
-
-from cect.Cells import GENERIC_CHEM_SYN
-from cect.Cells import GENERIC_ELEC_SYN
+from cect.Cells import (
+    GENERIC_CHEM_SYN,
+    GENERIC_ELEC_SYN,
+    convert_to_preferred_muscle_name,
+    is_herm_neuron,
+    is_known_muscle,
+    is_potential_muscle,
+    remove_leading_index_zero,
+)
+from cect.ConnectomeDataset import LOAD_READERS_FROM_CACHE_BY_DEFAULT, ConnectomeDataset
+from cect.ConnectomeReader import ConnectionInfo, analyse_connections
 
 
 def get_syntype(syntype):

--- a/cect/WhiteDataReader.py
+++ b/cect/WhiteDataReader.py
@@ -19,7 +19,12 @@ from cect.Cells import (
     is_potential_muscle,
     remove_leading_index_zero,
 )
-from cect.ConnectomeDataset import LOAD_READERS_FROM_CACHE_BY_DEFAULT, ConnectomeDataset
+from cect.ConnectomeDataset import (
+    LOAD_READERS_FROM_CACHE_BY_DEFAULT,
+    ConnectomeDataset,
+    get_cache_filename,
+    load_connectome_dataset_file,
+)
 from cect.ConnectomeReader import ConnectionInfo, analyse_connections
 
 
@@ -112,8 +117,15 @@ class WhiteDataReader(ConnectomeDataset):
 
         return list(neurons), list(muscles), list(other_cells), conns
 
-def get_instance(from_cache: bool =LOAD_READERS_FROM_CACHE_BY_DEFAULT, **kwargs) -> WhiteDataReader:
-    instance = WhiteDataReader(kwargs['spreadsheet_location'])
+def get_cache() -> ConnectomeDataset | None:
+    filename = get_cache_filename(__file__.split("/")[-1].split(".")[0])
+    file = load_connectome_dataset_file(filename)
+    output = file or None
+    return output
+
+def get_instance(from_cache: bool = LOAD_READERS_FROM_CACHE_BY_DEFAULT, **kwargs) -> ConnectomeDataset:
+    cache = get_cache() if from_cache else None
+    instance: ConnectomeDataset | None = cache or WhiteDataReader(kwargs['spreadsheet_location'])
     return instance
 
 

--- a/cect/WhiteDataReader.py
+++ b/cect/WhiteDataReader.py
@@ -15,6 +15,7 @@ from cect.Cells import is_potential_muscle
 from cect.Cells import is_known_muscle
 from cect.Cells import remove_leading_index_zero
 
+from cect.ConnectomeDataset import LOAD_READERS_FROM_CACHE_BY_DEFAULT
 from cect.ConnectomeDataset import ConnectomeDataset
 
 import os
@@ -113,6 +114,10 @@ class WhiteDataReader(ConnectomeDataset):
                         other_cells.add(p)
 
         return list(neurons), list(muscles), list(other_cells), conns
+
+def get_instance(from_cache: bool =LOAD_READERS_FROM_CACHE_BY_DEFAULT, **kwargs) -> WhiteDataReader:
+    instance = WhiteDataReader(kwargs['spreadsheet_location'])
+    return instance
 
 
 if __name__ == "__main__":

--- a/cect/tests/test_white_data_reader.py
+++ b/cect/tests/test_white_data_reader.py
@@ -1,10 +1,21 @@
+import unittest
 from pathlib import Path
 
-from cect.WhiteDataReader import get_instance, WhiteDataReader
+from cect.ConnectomeDataset import (
+    ConnectomeDataset,
+    get_cache_filename,
+)
+from cect.WhiteDataReader import WhiteDataReader, get_cache, get_instance
 
-import unittest
 
 class TestReader(unittest.TestCase):
+    def setUp(self):
+       self.cache_files_to_cleanup = [] 
+
+    def tearDown(self):
+        for file in self.cache_files_to_cleanup:
+            Path(file).unlink(missing_ok=True)
+
     def test_get_instance(self):
         current_filepath = Path(__file__)
         spreadsheet_directory: Path = current_filepath.parents[1] / "data"
@@ -17,6 +28,22 @@ class TestReader(unittest.TestCase):
         
         assert isinstance(instance, WhiteDataReader), "Instance should be of type WhiteDataReader"
         assert any([any(_) for _ in data]), "Instance should contain data"
+
+    def test_get_cache(self):
+        current_filepath = Path(__file__)
+        spreadsheet_directory: Path = current_filepath.parents[1] / "data"
+        spreadsheet_filepath: Path = spreadsheet_directory / "aconnectome_white_1986_whole.csv"
+        filename = str(spreadsheet_filepath)
+        self.cache_files_to_cleanup.append(get_cache_filename('WhiteDataReader'))
+        instance: WhiteDataReader = get_instance(from_cache=False, spreadsheet_location=filename)
+        instance.save_to_cache('WhiteDataReader')
+        
+        cache: ConnectomeDataset | None = get_cache()
+
+        assert cache is not None, "Cache should not be None"
+        assert any([any(_) for _ in cache._read_data()]), "Cache should contain data"
+        assert isinstance(cache, ConnectomeDataset), "Cache should be of type WhiteDataReader"
+        assert instance._read_data() == cache._read_data(), "Data from instance and cache should be identical"
 
 if __name__ == "__main__":
     unittest.main()

--- a/cect/tests/test_white_data_reader.py
+++ b/cect/tests/test_white_data_reader.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from cect.WhiteDataReader import get_instance, WhiteDataReader
+
+import unittest
+
+class TestReader(unittest.TestCase):
+    def test_get_instance(self):
+        current_filepath = Path(__file__)
+        spreadsheet_directory: Path = current_filepath.parents[1] / "data"
+        spreadsheet_filepath: Path = spreadsheet_directory / "aconnectome_white_1986_whole.csv"
+
+        assert spreadsheet_filepath.is_file(), f"Test data file should exist at {spreadsheet_filepath}"
+        filename = str(spreadsheet_filepath)
+        instance: WhiteDataReader = get_instance(from_cache=False, spreadsheet_location=filename)
+        data: tuple = instance.read_data()
+        
+        assert isinstance(instance, WhiteDataReader), "Instance should be of type WhiteDataReader"
+        assert any([any(_) for _ in data]), "Instance should contain data"
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Create a `get_instance` function for the WhiteDataReader.

WhiteDataReader has not had a `get_instance` function like the other classes and files. This PR develops, implements, and tests the function. Abstracted caching logic is included, which could also be extended to other data readers.

**Notes:**
- This functionality was tested using unittest, and should be pytest compatible. I can convert to pytest if needed.
- The imports have been rearranged to conform with [PEP 8 import guidelines](https://peps.python.org/pep-0008/#imports) 